### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Assets/TextMeshPro/* linguist-vendored


### PR DESCRIPTION
Create .gitattributes to tell Linguist to ignore TextMeshPro's asset folder